### PR TITLE
Migrate to apt-archive

### DIFF
--- a/NETWORK.md
+++ b/NETWORK.md
@@ -31,14 +31,14 @@ docker network inspect -v pglogical-poc_default
         "ConfigOnly": false,
         "Containers": {
             "80ae5b2beb40ada3120ba98e3dc76d15cadb9f0fa0187c015b4ae60d2e3e791a": {
-                "Name": "pglogical-poc_pgsubscriber_1",
+                "Name": "pglogical-poc-pgsubscriber-1",
                 "EndpointID": "592114feb099a1d10d2cc5d7731506c0aa4b02e039431646b3ed3f050e5bf802",
                 "MacAddress": "02:42:c0:a8:90:03",
                 "IPv4Address": "192.168.144.3/20",
                 "IPv6Address": ""
             },
             "b59e6fbe72657a6d32fc6f9ea33c58c718c259999683bd0c2d77a5781e81c949": {
-                "Name": "pglogical-poc_pgprovider_1",
+                "Name": "pglogical-poc-pgprovider-1",
                 "EndpointID": "42d00c26782cacf672113d320ffc61b4e237e65adfa48b5f590a74df16a5b62d",
                 "MacAddress": "02:42:c0:a8:90:02",
                 "IPv4Address": "192.168.144.2/20",
@@ -59,11 +59,11 @@ docker network inspect -v pglogical-poc_default
 # get running processes
 docker ps --format 'table {{.ID}}\t{{.Names}}'
 CONTAINER ID   NAMES
-80ae5b2beb40   pglogical-poc_pgsubscriber_1
-b59e6fbe7265   pglogical-poc_pgprovider_1
+80ae5b2beb40   pglogical-poc-pgsubscriber-1
+b59e6fbe7265   pglogical-poc-pgprovider-1
 
 # get hosts from pgprovider
-docker exec pglogical-poc_pgprovider_1 cat /etc/hosts
+docker exec pglogical-poc-pgprovider-1 cat /etc/hosts
 127.0.0.1	localhost
 ::1	localhost ip6-localhost ip6-loopback
 fe00::0	ip6-localnet
@@ -73,7 +73,7 @@ ff02::2	ip6-allrouters
 192.168.144.2	b59e6fbe7265
 
 # get hosts from pgsubscriber
-docker exec pglogical-poc_pgsubscriber_1 cat /etc/hosts
+docker exec pglogical-poc-pgsubscriber-1 cat /etc/hosts
 127.0.0.1	localhost
 ::1	localhost ip6-localhost ip6-loopback
 fe00::0	ip6-localnet
@@ -85,7 +85,7 @@ ff02::2	ip6-allrouters
 
 ```bash
 # connect to other psql instance using host
-docker exec -it pglogical-poc_pgprovider_1 /bin/bash
+docker exec -it pglogical-poc-pgprovider-1 /bin/bash
 root@b59e6fbe7265:/# psql -h pgsubscriber -U replicate pg_logical_replication_results
 psql (11.5 (Debian 11.5-3.pgdg90+1), server 11.10 (Debian 11.10-1.pgdg90+1))
 Type "help" for help.

--- a/SCENARIOS.md
+++ b/SCENARIOS.md
@@ -9,32 +9,32 @@ We run a migration that adds a column with a default value. When we try to repli
 docker-compose up -d
 
 # run migrations
-docker exec -it pglogical-poc_pgprovider_1 \
+docker exec -it pglogical-poc-pgprovider-1 \
   psql -U postgres -d pg_logical_replication -f /migration.sql
 
-docker exec -it pglogical-poc_pgsubscriber_1 \
+docker exec -it pglogical-poc-pgsubscriber-1 \
   psql -U postgres -d pg_logical_replication_results -f /migration.sql
 
 # check schema
-docker exec -it pglogical-poc_pgprovider_1 \
+docker exec -it pglogical-poc-pgprovider-1 \
   psql -U postgres -d pg_logical_replication \
     -c '\d+ comments'
-docker exec -it pglogical-poc_pgprovider_1 \
+docker exec -it pglogical-poc-pgprovider-1 \
   psql -U postgres -d pg_logical_replication \
     -c 'SELECT * FROM comments LIMIT 1;'
 
-docker exec -it pglogical-poc_pgsubscriber_1 \
+docker exec -it pglogical-poc-pgsubscriber-1 \
   psql -U postgres -d pg_logical_replication_results -c '\d+ comments'
 
 # configure and start replication
-docker exec -it pglogical-poc_pgprovider_1 \
+docker exec -it pglogical-poc-pgprovider-1 \
   psql -U postgres -d pg_logical_replication -f /replication.sql
 
-docker exec -it pglogical-poc_pgsubscriber_1 \
+docker exec -it pglogical-poc-pgsubscriber-1 \
   psql -U postgres -d pg_logical_replication_results -f /replication.sql
 
 # check logs
-docker logs pglogical-poc_pgsubscriber_1
+docker logs pglogical-poc-pgsubscriber-1
 ```
 
 ```text
@@ -54,32 +54,32 @@ docker-compose down --rmi all
 docker-compose up -d --build
 
 # run migrations
-docker exec -it pglogical-poc_pgprovider_1 \
+docker exec -it pglogical-poc-pgprovider-1 \
   psql -U postgres -d pg_logical_replication -f /migration.sql
 
-docker exec -it pglogical-poc_pgsubscriber_1 \
+docker exec -it pglogical-poc-pgsubscriber-1 \
   psql -U postgres -d pg_logical_replication_results -f /migration.sql
 
 # run backfill
-docker exec -it pglogical-poc_pgprovider_1 \
+docker exec -it pglogical-poc-pgprovider-1 \
   psql -U postgres -d pg_logical_replication -f /backfill.sql
 
 # configure and start replication
-docker exec -it pglogical-poc_pgprovider_1 \
+docker exec -it pglogical-poc-pgprovider-1 \
   psql -U postgres -d pg_logical_replication -f /replication.sql
 
-docker exec -it pglogical-poc_pgsubscriber_1 \
+docker exec -it pglogical-poc-pgsubscriber-1 \
   psql -U postgres -d pg_logical_replication_results -f /replication.sql
 
 # check logs
-docker logs pglogical-poc_pgsubscriber_1
+docker logs pglogical-poc-pgsubscriber-1
 
 # check entries
-docker exec -it pglogical-poc_pgprovider_1 \
+docker exec -it pglogical-poc-pgprovider-1 \
   psql -U postgres -d pg_logical_replication \
     -c 'SELECT * FROM comments WHERE user_id = 1;'
 
-docker exec -it pglogical-poc_pgsubscriber_1 \
+docker exec -it pglogical-poc-pgsubscriber-1 \
   psql -U postgres -d pg_logical_replication_results \
     -c 'SELECT * FROM comments;'
 ```
@@ -94,28 +94,28 @@ docker-compose down --rmi all
 docker-compose up -d --build
 
 # run migrations
-docker exec -it pglogical-poc_pgprovider_1 \
+docker exec -it pglogical-poc-pgprovider-1 \
   psql -U postgres -d pg_logical_replication -f /migration-2.sql
 
-docker exec -it pglogical-poc_pgsubscriber_1 \
+docker exec -it pglogical-poc-pgsubscriber-1 \
   psql -U postgres -d pg_logical_replication_results -f /migration-2.sql
 
 # configure and start replication
-docker exec -it pglogical-poc_pgprovider_1 \
+docker exec -it pglogical-poc-pgprovider-1 \
   psql -U postgres -d pg_logical_replication -f /replication.sql
 
-docker exec -it pglogical-poc_pgsubscriber_1 \
+docker exec -it pglogical-poc-pgsubscriber-1 \
   psql -U postgres -d pg_logical_replication_results -f /replication.sql
 
 # check logs
-docker logs pglogical-poc_pgsubscriber_1
+docker logs pglogical-poc-pgsubscriber-1
 
 # check entries
-docker exec -it pglogical-poc_pgprovider_1 \
+docker exec -it pglogical-poc-pgprovider-1 \
   psql -U postgres -d pg_logical_replication \
     -c 'SELECT * FROM comments WHERE user_id = 1;'
 
-docker exec -it pglogical-poc_pgsubscriber_1 \
+docker exec -it pglogical-poc-pgsubscriber-1 \
   psql -U postgres -d pg_logical_replication_results \
     -c 'SELECT * FROM comments;'
 ```
@@ -134,21 +134,21 @@ docker compose up -d
 #   - pglogical.create_node
 #   - pglogical.create_replication_set
 #   - pglogical.replication_set_add_table
-docker exec -it pglogical-poc_pgprovider_1 \
+docker exec -it pglogical-poc-pgprovider-1 \
   psql -U postgres -d pg_logical_replication -f /replication.sql
 
 # second for the subscriber:
 #   - pglogical.create_node
 #   - pglogical.create_subscription
-docker exec -it pglogical-poc_pgsubscriber_1 \
+docker exec -it pglogical-poc-pgsubscriber-1 \
   psql -U postgres -d pg_logical_replication_results -f /replication.sql
 
 # initialize pgbench tables
-# docker exec -it pglogical-poc_pgprovider_1 \
+# docker exec -it pglogical-poc-pgprovider-1 \
 #   pgbench -i -U postgres -d pg_logical_replication
 
 # check tables
-# docker exec -it pglogical-poc_pgprovider_1 \
+# docker exec -it pglogical-poc-pgprovider-1 \
 #   psql -U postgres -d pg_logical_replication \
 #     -c 'SELECT
 #           (SELECT COUNT(1) FROM pgbench_accounts) AS accounts,
@@ -157,7 +157,7 @@ docker exec -it pglogical-poc_pgsubscriber_1 \
 #           (SELECT COUNT(1) FROM pgbench_tellers) AS tellers;'
 
 # run pgbench with 10 threads and 10.000 transactions
-docker exec -it pglogical-poc_pgprovider_1 \
+docker exec -it pglogical-poc-pgprovider-1 \
   pgbench -U postgres -d pg_logical_replication \
     -c 10 -j 2 -t 10000 -f pgbench.sql
 ```

--- a/provider/Dockerfile
+++ b/provider/Dockerfile
@@ -1,6 +1,12 @@
 FROM postgres:11.5
 
-RUN apt-get update && apt-get install -y curl
+# add apt-archive repository
+RUN echo "deb https://apt-archive.postgresql.org/pub/repos/apt stretch-pgdg-archive main\ndeb-src https://apt-archive.postgresql.org/pub/repos/apt stretch-pgdg-archive main" > /etc/apt/sources.list.d/pgdg.list
+RUN apt-get update || true && \
+  apt-get install -y apt-transport-https && \
+  apt-get update && \
+  apt-get install -y curl
+
 RUN curl https://dl.2ndquadrant.com/default/release/get/deb | bash && apt-get update
 
 ### IMPORTANT: use 2.2.2 instead of 2.2.1! Otherwise PG 11.5 is very sad!

--- a/subscriber/Dockerfile
+++ b/subscriber/Dockerfile
@@ -1,6 +1,12 @@
 FROM postgres:11.10
 
-RUN apt-get update && apt-get install -y curl
+# add apt-archive repository
+RUN echo "deb https://apt-archive.postgresql.org/pub/repos/apt stretch-pgdg-archive main\ndeb-src https://apt-archive.postgresql.org/pub/repos/apt stretch-pgdg-archive main" > /etc/apt/sources.list.d/pgdg.list
+RUN apt-get update || true && \
+  apt-get install -y apt-transport-https && \
+  apt-get update && \
+  apt-get install -y curl
+
 RUN curl https://dl.2ndquadrant.com/default/release/get/deb | bash && apt-get update
 
 ### IMPORTANT: use 2.2.2 instead of 2.2.1! Otherwise PG 11.10 is very sad!


### PR DESCRIPTION
Migrate to apt-archive in order to still use Postgres 11 based on Debian 9 (stretch).